### PR TITLE
Add Debian 12, and fix debian-security repo

### DIFF
--- a/src/components/helps/CentOS-Vault.vue
+++ b/src/components/helps/CentOS-Vault.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <h1>CentOS-Valut镜像使用指南</h1>
+    <h1>CentOS-Vault 镜像使用指南</h1>
     <div>
       <div class="select-version">
         <strong>选择你的CentOS版本:</strong>
       </div>
       <div class="select-version">
         <el-select v-model="selected" placeholder="请选择" v-on:change="handleSelect()">
-          <el-option value="CentOS7Before">CentOS7及之前</el-option>
+          <el-option value="CentOS7Before">CentOS 7 及之前</el-option>
           <el-option value="CentOS8"></el-option>
         </el-select>
       </div>
@@ -21,11 +21,11 @@
 
 <script>
 export default {
-  name: 'CentOS-Valut',
+  name: 'CentOS-Vault',
   data () {
     return {
       selected: 'CentOS7Before',
-      content: 'CentOS7及之前'
+      content: 'CentOS 7 及之前'
     }
   },
   mounted () {

--- a/src/components/helps/Debian.vue
+++ b/src/components/helps/Debian.vue
@@ -27,27 +27,41 @@ export default {
       content_raw: '',
       versions: [
         {
-          version: 'testing',
-          codename: 'testing'
+          version: 'Debian Unstable (Sid)',
+          codename: 'sid',
+          security_suffix: '-security'
         },
         {
-          version: 'bullseye',
-          codename: 'bullseye'
+          version: 'Debian Testing 13 (Trixie)',
+          codename: 'trixie',
+          security_suffix: '-security'
         },
         {
-          version: 'buster',
-          codename: 'buster'
+          version: 'Debian 12 (Bookworm)',
+          codename: 'bookworm',
+          security_suffix: '-security'
         },
         {
-          version: 'stretch',
-          codename: 'stretch'
+          version: 'Debian 11 (Bullseye)',
+          codename: 'bullseye',
+          security_suffix: '-security'
+        },
+        {
+          version: 'Debian 10 (Buster)',
+          codename: 'buster',
+          security_suffix: '/updates'
+        },
+        {
+          version: 'Debian 9 (Stretch)',
+          codename: 'stretch',
+          security_suffix: '/updates'
         }
       ],
       version: null
     }
   },
   created () {
-    this.version = this.versions[1]
+    this.version = this.versions[2]
   },
   mounted () {
     this.$axios.get('/static/help/Debian.md').then((response) => {
@@ -68,9 +82,9 @@ export default {
         return ''
       }
       return this.content_raw.replace(
-        /{debian_version}/g, this.version.version
-      ).replace(
         /{debian_codename}/g, this.version.codename
+      ).replace(
+        /{debian_security}/g, this.version.security_suffix
       )
     }
   }


### PR DESCRIPTION
The name for the security updates repo `{codename}-security` was once `{codename}/updates`, as announced in the mailing list: https://lists.debian.org/debian-devel-announce/2019/07/msg00004.html.
This patch works together with https://github.com/PKUOSC/Mirror-doc/pull/7 to fix this problem.

The new stable release Debian 12 and the new testing repo Debian 13 were also added to the list.